### PR TITLE
Use NonInteractive Mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,5 +5,5 @@
   with_items: "{{ ansible_locales }}"
 
 - name: Reconfigure System Locales
-  command: dpkg-reconfigure locales
+  command: dpkg-reconfigure -f noninteractive locales
   become: yes


### PR DESCRIPTION
:elephant:

* On some setups, `dpkg-reconfigure` will open up in interactive mode.
* This will force ansible to wait indefinitely.
* Use the noninteractive flag for `dpkg-reconfigure`.